### PR TITLE
Bump version to match version on hackage

### DIFF
--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 Name:                ansi-wl-pprint
-Version:             0.6.7
+Version:             0.6.7.1
 Cabal-Version:       >= 1.2
 Category:            User Interfaces, Text
 Synopsis:            The Wadler/Leijen Pretty Printer for colored ANSI terminal output


### PR DESCRIPTION
The hackage upload has a newer version than https://github.com/batterseapower/ansi-wl-pprint, so when one tries to use 0.6.7 from the pr-base48 branch it gets replaced by the unpatched 0.6.7.1 on hackage.